### PR TITLE
Add zoom controls and improve plot layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Text Embedding Explorer transforms text data into visual insights by plotting hi
 
 ### Key Features
 
-- **Interactive Visualization**: Plotly-powered scatter plot with smooth zoom, pan, and selection
+- **Interactive Visualization**: Plotly-powered scatter plot with smooth zoom, pan, and selection. Dedicated buttons and scroll wheel controls let you zoom in, zoom out, and return home.
 - **AI-Powered Analysis**: Integration with OpenAI API for intelligent text analysis
 - **Flexible Selection**: Lasso and box selection tools with keyboard shortcuts
 - **Real-time Preview**: Instant preview of selected data points with metadata

--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
                         <button class="tool-btn" onclick="setSelectionMode('box')" title="Box Selection (Shift+B)">□</button>
                         <button class="tool-btn" onclick="clearSelection()" title="Clear Selection (Shift+C)">✕</button>
                     </div>
+                    <div class="zoom-controls">
+                        <button class="tool-btn" onclick="zoomIn()" title="Zoom In (+)">+</button>
+                        <button class="tool-btn" onclick="zoomOut()" title="Zoom Out (-)">−</button>
+                        <button class="tool-btn" onclick="resetZoom()" title="Reset Zoom (Home)">⌂</button>
+                    </div>
                 </div>
             </div>
             <div class="plot-container">

--- a/js/app.js
+++ b/js/app.js
@@ -44,6 +44,9 @@ class EmbeddingExplorerApp {
         
         window.setSelectionMode = (mode) => this.visualizationManager.setSelectionMode(mode);
         window.clearSelection = () => this.visualizationManager.clearSelection();
+        window.zoomIn = () => this.visualizationManager.zoomIn();
+        window.zoomOut = () => this.visualizationManager.zoomOut();
+        window.resetZoom = () => this.visualizationManager.resetZoom();
         
     }
     
@@ -97,6 +100,22 @@ class EmbeddingExplorerApp {
                         break;
                 }
             }
+
+            switch(event.key) {
+                case '+':
+                case '=':
+                    event.preventDefault();
+                    this.visualizationManager.zoomIn();
+                    break;
+                case '-':
+                    event.preventDefault();
+                    this.visualizationManager.zoomOut();
+                    break;
+                case 'Home':
+                    event.preventDefault();
+                    this.visualizationManager.resetZoom();
+                    break;
+            }
         });
     }
     
@@ -104,5 +123,4 @@ class EmbeddingExplorerApp {
 
 // Initialize the application when the DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
-    new EmbeddingExplorerApp();
-});
+    new EmbeddingExplorerApp();});

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -4,6 +4,8 @@ export class VisualizationManager {
         this.dataManager = dataManager;
         this.selectedIndices = new Set();
         this.selectionMode = 'lasso';
+        this.defaultXRange = null;
+        this.defaultYRange = null;
         this.categoryColors = [
             '#4a9eff', '#ff6b6b', '#4ecdc4', '#45b7d1', '#f7b731',
             '#5f27cd', '#00d2d3', '#ff9ff3', '#54a0ff', '#48dbfb'
@@ -16,6 +18,15 @@ export class VisualizationManager {
     initializePlot() {
         const embeddings = this.dataManager.getEmbeddings();
         const categories = this.dataManager.getCategories();
+
+        const xValues = embeddings.map(e => e.x);
+        const yValues = embeddings.map(e => e.y);
+        const xMin = Math.min(...xValues);
+        const xMax = Math.max(...xValues);
+        const yMin = Math.min(...yValues);
+        const yMax = Math.max(...yValues);
+        this.defaultXRange = [xMin, xMax];
+        this.defaultYRange = [yMin, yMax];
         
         const trace = {
             x: embeddings.map(e => e.x),
@@ -50,19 +61,21 @@ export class VisualizationManager {
         
         const layout = {
             title: '',
-            xaxis: { 
-                title: '', 
+            xaxis: {
+                title: '',
                 showgrid: true,
                 gridcolor: '#2a2a2a',
                 zerolinecolor: '#3a3a3a',
-                tickfont: { color: '#aaa' }
+                tickfont: { color: '#aaa' },
+                range: this.defaultXRange
             },
-            yaxis: { 
-                title: '', 
+            yaxis: {
+                title: '',
                 showgrid: true,
                 gridcolor: '#2a2a2a',
                 zerolinecolor: '#3a3a3a',
-                tickfont: { color: '#aaa' }
+                tickfont: { color: '#aaa' },
+                range: this.defaultYRange
             },
             paper_bgcolor: '#0a0a0a',
             plot_bgcolor: '#0a0a0a',
@@ -75,7 +88,8 @@ export class VisualizationManager {
         const config = {
             responsive: true,
             displayModeBar: false,
-            staticPlot: false
+            staticPlot: false,
+            scrollZoom: true
         };
         
         Plotly.newPlot('plot', [trace], layout, config).then(() => {
@@ -98,6 +112,10 @@ export class VisualizationManager {
             
             this.updateVisualization();
             this.onSelectionChange?.(this.selectedIndices);
+        });
+
+        document.getElementById('plot').on('plotly_deselect', () => {
+            this.clearSelection();
         });
     }
     
@@ -178,7 +196,39 @@ export class VisualizationManager {
     getSelectedIndices() {
         return new Set(this.selectedIndices);
     }
-    
+
+    zoom(factor) {
+        const plot = document.getElementById('plot');
+        const xaxis = plot.layout.xaxis;
+        const yaxis = plot.layout.yaxis;
+        const xCenter = (xaxis.range[0] + xaxis.range[1]) / 2;
+        const yCenter = (yaxis.range[0] + yaxis.range[1]) / 2;
+        const xHalf = (xaxis.range[1] - xaxis.range[0]) * factor / 2;
+        const yHalf = (yaxis.range[1] - yaxis.range[0]) * factor / 2;
+        Plotly.relayout('plot', {
+            'xaxis.range': [xCenter - xHalf, xCenter + xHalf],
+            'yaxis.range': [yCenter - yHalf, yCenter + yHalf]
+        });
+    }
+
+    zoomIn() {
+        this.zoom(0.8);
+    }
+
+    zoomOut() {
+        this.zoom(1.25);
+    }
+
+    resetZoom() {
+        Plotly.relayout('plot', {
+            'xaxis.range': this.defaultXRange,
+            'yaxis.range': this.defaultYRange
+        });
+    }
+
+    handleResize() {
+        Plotly.Plots.resize('plot');
+    }
+
     // Callback for when selection changes
-    onSelectionChange = null;
-}
+    onSelectionChange = null;}

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,11 @@ body {
     display: block;
 }
 
+#plot {
+    width: 100%;
+    height: 100%;
+}
+
 .tooltip {
     background-color: rgba(26, 26, 26, 0.95);
     border: 1px solid #3a3a3a;


### PR DESCRIPTION
## Summary
- add zoom in/out buttons and home button
- enable scroll wheel zoom
- reset point colors when deselecting
- make plot fill available space
- document zoom controls

## Testing
- `npm test` *(fails: Missing script)*
- `npm run serve --version`

------
https://chatgpt.com/codex/tasks/task_e_686e5077ca908323ab0f3e454be1d70a