### PR TITLE
Fix selection mode controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,14 +15,14 @@
             <div class="visualization-header">
                 <div class="header-controls">
                     <div class="control-group">
-                        <button class="tool-btn active" onclick="setSelectionMode('lasso')" title="Lasso Selection (Shift+L)">○</button>
-                        <button class="tool-btn" onclick="setSelectionMode('box')" title="Box Selection (Shift+B)">□</button>
-                        <button class="tool-btn" onclick="clearSelection()" title="Clear Selection (Shift+C)">✕</button>
+                        <button class="tool-btn active" data-mode="lasso" onclick="setSelectionMode('lasso')" title="Lasso Selection (Shift+L)">○</button>
+                        <button class="tool-btn" data-mode="box" onclick="setSelectionMode('box')" title="Box Selection (Shift+B)">□</button>
+                        <button class="tool-btn" id="clearBtn" onclick="clearSelection()" title="Clear Selection (Shift+C)">✕</button>
                     </div>
                     <div class="zoom-controls">
-                        <button class="tool-btn" onclick="zoomIn()" title="Zoom In (+)">+</button>
-                        <button class="tool-btn" onclick="zoomOut()" title="Zoom Out (-)">−</button>
-                        <button class="tool-btn" onclick="resetZoom()" title="Reset Zoom (Home)">⌂</button>
+                        <button class="tool-btn" id="zoomInBtn" onclick="zoomIn()" title="Zoom In (+)">+</button>
+                        <button class="tool-btn" id="zoomOutBtn" onclick="zoomOut()" title="Zoom Out (-)">−</button>
+                        <button class="tool-btn" id="resetBtn" onclick="resetZoom()" title="Reset Zoom (Home)">⌂</button>
                     </div>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -1061,7 +1061,7 @@ textarea:focus-visible {
     cursor: crosshair;
 }
 
-/* Polygon Selection Styles */
+/* Lasso Selection Styles */
 .polygon-selection {
     pointer-events: none;
 }
@@ -1083,12 +1083,12 @@ textarea:focus-visible {
     transform: scale(1.1);
 }
 
-/* Visual feedback for polygon selection mode */
-.main-panel[data-selection-mode="polygon"] #visualization {
+/* Visual feedback for lasso selection mode */
+.main-panel[data-selection-mode="lasso"] #visualization {
     cursor: crosshair;
 }
 
-.main-panel[data-selection-mode="polygon"] .plot-background {
+.main-panel[data-selection-mode="lasso"] .plot-background {
     cursor: crosshair;
 }
 
@@ -1117,7 +1117,7 @@ textarea:focus-visible {
 }
 
 /* Enhanced visual feedback for selection modes */
-.tool-btn[data-mode="polygon"].active::after {
+.tool-btn[data-mode="lasso"].active::after {
     content: '';
     position: absolute;
     bottom: -2px;
@@ -1132,5 +1132,4 @@ textarea:focus-visible {
 
 @keyframes pulse {
     0%, 100% { opacity: 1; transform: translateX(-50%) scale(1); }
-    50% { opacity: 0.5; transform: translateX(-50%) scale(1.2); }
-}
+    50% { opacity: 0.5; transform: translateX(-50%) scale(1.2); }}


### PR DESCRIPTION
## Summary
- align selection mode names with UI (`lasso` & `box`)
- update event handlers to avoid missing elements
- wire up toolbar buttons with `data-mode` attributes
- tweak lasso styles

## Testing
- `npm start` *(fails: address in use when already running)*

------
https://chatgpt.com/codex/tasks/task_e_686e971a48448323b8cc404fc27ec3da