### PR TITLE
Improve accessibility for toolbar and results panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,14 +15,14 @@
             <div class="visualization-header">
                 <div class="header-controls">
                     <div class="control-group">
-                        <button class="tool-btn active" data-mode="lasso" onclick="setSelectionMode('lasso')" title="Lasso Selection (Shift+L)">○</button>
-                        <button class="tool-btn" data-mode="box" onclick="setSelectionMode('box')" title="Box Selection (Shift+B)">□</button>
-                        <button class="tool-btn" id="clearBtn" onclick="clearSelection()" title="Clear Selection (Shift+C)">✕</button>
+                        <button class="tool-btn active" data-mode="lasso" onclick="setSelectionMode('lasso')" title="Lasso Selection (Shift+L)" aria-label="Lasso selection mode">○</button>
+                        <button class="tool-btn" data-mode="box" onclick="setSelectionMode('box')" title="Box Selection (Shift+B)" aria-label="Box selection mode">□</button>
+                        <button class="tool-btn" id="clearBtn" onclick="clearSelection()" title="Clear Selection (Shift+C)" aria-label="Clear selection">✕</button>
                     </div>
                     <div class="zoom-controls">
-                        <button class="tool-btn" id="zoomInBtn" onclick="zoomIn()" title="Zoom In (+)">+</button>
-                        <button class="tool-btn" id="zoomOutBtn" onclick="zoomOut()" title="Zoom Out (-)">−</button>
-                        <button class="tool-btn" id="resetBtn" onclick="resetZoom()" title="Reset Zoom (Home)">⌂</button>
+                        <button class="tool-btn" id="zoomInBtn" onclick="zoomIn()" title="Zoom In (+)" aria-label="Zoom in">+</button>
+                        <button class="tool-btn" id="zoomOutBtn" onclick="zoomOut()" title="Zoom Out (-)" aria-label="Zoom out">−</button>
+                        <button class="tool-btn" id="resetBtn" onclick="resetZoom()" title="Reset Zoom (Home)" aria-label="Reset zoom">⌂</button>
                     </div>
                 </div>
             </div>
@@ -71,9 +71,11 @@
                     <div class="action-panel">
                         <label for="promptInput" class="prompt-label">Analysis Prompt</label>
                         <textarea class="prompt-input" id="promptInput" placeholder="Enter your analysis prompt..." aria-describedby="prompt-help">Analyze these items and identify common themes, patterns, or groupings.</textarea>
+                        <p id="prompt-help" class="visually-hidden">Enter a prompt describing how the selection should be analyzed.</p>
                         <button class="button" id="analyzeBtn" onclick="showConfirmation()" disabled aria-describedby="analyze-help">
                             Analyze Selection
                         </button>
+                        <p id="analyze-help" class="visually-hidden">Send the selected points and prompt to the analysis service.</p>
                     </div>
                 </details>
             </div>

--- a/js/d3-visualization.js
+++ b/js/d3-visualization.js
@@ -434,10 +434,15 @@ export class D3VisualizationManager {
         const container = d3.select('.plot-container');
         const instructions = container.append('div')
             .attr('class', 'polygon-instructions')
+            .attr('role', 'status')
+            .attr('aria-live', 'polite')
+            .attr('tabindex', '-1')
             .html(`
                 <div><strong>Lasso Selection Mode</strong></div>
                 <div>Click to add vertices • Click first vertex or double-click to complete</div>
             `);
+
+        instructions.node().focus();
         
         // Auto-remove after 4 seconds
         setTimeout(() => {

--- a/styles.css
+++ b/styles.css
@@ -918,7 +918,7 @@ details[open] summary {
     position: fixed;
     bottom: 0;
     left: 0;
-    right: 380px;
+    right: var(--sidebar-width);
     background-color: #0f0f0f;
     border-top: 1px solid #2a2a2a;
     height: 300px;


### PR DESCRIPTION
## Summary
- add ARIA labels to toolbar buttons
- provide hidden helper text for prompt and analyze actions
- make results panel width respect sidebar
- announce polygon instructions to screen readers

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687187a7a3448323b44dd2d6cc14aa94