### PR TITLE
Add CSV upload and demo mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
                         <button class="tool-btn" id="zoomOutBtn" onclick="zoomOut()" title="Zoom Out (-)" aria-label="Zoom out">−</button>
                         <button class="tool-btn" id="resetBtn" onclick="resetZoom()" title="Reset Zoom (Home)" aria-label="Reset zoom">⌂</button>
                     </div>
+                    <div class="data-controls">
+                        <button class="tool-btn" id="uploadBtn" onclick="triggerUpload()" title="Upload CSV Dataset" aria-label="Upload dataset">⬆</button>
+                        <button class="tool-btn" id="demoBtn" onclick="resetToDemoData()" title="Load Demo Data" aria-label="Load demo data">⟳</button>
+                        <input type="file" id="uploadInput" accept=".csv" style="display:none" onchange="handleFileInput(event)">
+                    </div>
                 </div>
             </div>
             <div class="plot-container">

--- a/js/app.js
+++ b/js/app.js
@@ -47,7 +47,17 @@ class EmbeddingExplorerApp {
         window.zoomIn = () => this.visualizationManager.zoomIn();
         window.zoomOut = () => this.visualizationManager.zoomOut();
         window.resetZoom = () => this.visualizationManager.resetZoom();
-        
+
+        window.triggerUpload = () => document.getElementById('uploadInput').click();
+        window.handleFileInput = (e) => {
+            const file = e.target.files[0];
+            if (file) {
+                this.handleFileUpload(file);
+            }
+            e.target.value = '';
+        };
+        window.resetToDemoData = () => this.resetToDemoData();
+
     }
     
     initialize() {
@@ -55,6 +65,8 @@ class EmbeddingExplorerApp {
         this.visualizationManager.populateLegend();
         this.visualizationManager.updateVisualization();
         this.uiManager.updateAnalyzeButton();
+
+        this.setupDragAndDrop();
         
         // Handle window resize for visualization
         window.addEventListener('resize', () => {
@@ -68,6 +80,47 @@ class EmbeddingExplorerApp {
         
         
         console.log('Embedding Explorer App initialized successfully');
+    }
+
+    async handleFileUpload(file) {
+        try {
+            await this.dataManager.loadCSVFile(file);
+            this.visualizationManager.reloadData();
+            this.uiManager.populateFieldCheckboxes();
+            this.uiManager.updateAnalyzeButton();
+        } catch (err) {
+            alert('Failed to load dataset: ' + err.message);
+        }
+    }
+
+    resetToDemoData() {
+        this.dataManager.resetToSampleData();
+        this.visualizationManager.reloadData();
+        this.uiManager.populateFieldCheckboxes();
+        this.uiManager.updateAnalyzeButton();
+    }
+
+    setupDragAndDrop() {
+        const container = document.querySelector('.plot-container');
+        if (!container) return;
+
+        container.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            container.classList.add('drag-over');
+        });
+
+        container.addEventListener('dragleave', () => {
+            container.classList.remove('drag-over');
+        });
+
+        container.addEventListener('drop', (e) => {
+            e.preventDefault();
+            container.classList.remove('drag-over');
+            const file = e.dataTransfer.files[0];
+            if (file) {
+                this.handleFileUpload(file);
+            }
+        });
     }
     
     setupKeyboardShortcuts() {
@@ -123,4 +176,5 @@ class EmbeddingExplorerApp {
 
 // Initialize the application when the DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
-    new EmbeddingExplorerApp();});
+    new EmbeddingExplorerApp();
+});

--- a/js/d3-visualization.js
+++ b/js/d3-visualization.js
@@ -546,7 +546,12 @@ export class D3VisualizationManager {
     }
     
     updateStats() {
+        const totalElement = document.getElementById('totalPoints');
         const selectedElement = document.getElementById('selectedPoints');
+
+        if (totalElement) {
+            totalElement.textContent = this.dataManager.getEmbeddings().length;
+        }
         if (selectedElement) {
             selectedElement.textContent = this.selectedIndices.size;
         }
@@ -706,5 +711,16 @@ export class D3VisualizationManager {
     getSelectedIndices() {
         return new Set(this.selectedIndices);
     }
-    
-    onSelectionChange = null;}
+
+    reloadData() {
+        this.svg.selectAll('*').remove();
+        this.selectedIndices.clear();
+        this.currentTransform = d3.zoomIdentity;
+        this.initializeVisualization();
+        this.populateLegend();
+        this.clearSelectionTools();
+        this.setupSelectionTool();
+    }
+
+    onSelectionChange = null;
+}

--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,12 @@ body {
     align-items: center;
 }
 
+.data-controls {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
 .top-bar-left {
     display: flex;
     align-items: center;
@@ -72,6 +78,10 @@ body {
     position: relative;
     overflow: hidden;
     min-height: 0;
+}
+
+.plot-container.drag-over {
+    outline: 2px dashed #4a9eff;
 }
 
 #visualization {


### PR DESCRIPTION
## Summary
- allow uploading CSV datasets with x and y columns
- provide buttons for upload and resetting to demo data
- add demo mode support in DataManager
- refresh visualization when data is reloaded
- support drag-and-drop CSV upload

## Testing
- `node --check js/app.js`
- `node --check js/data.js`
- `node --check js/d3-visualization.js`
- `node --check js/ui.js`
- `node --check js/analysis.js`
- `npm start --silent` *(interrupted after launch)*

------
https://chatgpt.com/codex/tasks/task_e_6871429fefc0832388c7f402ba8bd0ab