### PR TITLE
Remove double scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Text Embedding Explorer transforms text data into visual insights by plotting hi
 
 #### Analysis Workflow
 1. **Select Points**: Use keyboard shortcuts to choose selection mode, then click and drag on the plot
-2. **Review Selection**: Selected points appear in the expanded preview panel on the right
+2. **Review Selection**: All selected points appear in the preview panel on the right. Large selections are virtualized for smooth scrolling
 3. **Configure Analysis**: Click the settings icon (⚙) in the top-right of the sidebar to add your OpenAI API key
 4. **Analyze**: Enter your analysis prompt and click "Analyze Selection"
 

--- a/styles.css
+++ b/styles.css
@@ -302,7 +302,6 @@ body {
 .selection-info {
     padding: 20px;
     flex: 1;
-    overflow-y: auto;
     min-height: 0;
 }
 
@@ -478,6 +477,9 @@ details[open] .selection-info,
 details[open] .action-panel {
     flex: 1;
     min-height: 0;
+}
+
+details[open] .action-panel {
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- drop overflow from `.selection-info` so the preview container scrolls
- keep virtualization logic intact

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871996c88848323820bf9d17500a6c8