### PR TITLE
Organize sidebar tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Text Embedding Explorer transforms text data into visual insights by plotting hi
 
 #### Analysis Workflow
 1. **Select Points**: Use keyboard shortcuts to choose selection mode, then click and drag on the plot
-2. **Review Selection**: Selected points appear in the expanded preview panel on the right
+2. **Review Selection**: Open the **Preview** tab to see all selected points. Large selections are virtualized for smooth scrolling
 3. **Configure Analysis**: Click the settings icon (⚙) in the top-right of the sidebar to add your OpenAI API key
-4. **Analyze**: Enter your analysis prompt and click "Analyze Selection"
+4. **Analyze**: Switch to the **Analysis** tab, enter your prompt and click "Analyze Selection"
 
 ### Settings Configuration
 

--- a/index.html
+++ b/index.html
@@ -55,11 +55,12 @@
             </div>
             
             <div class="panel-tabs">
-                <button class="tab-btn active" data-tab="selection">Selection</button>
+                <button class="tab-btn active" data-tab="preview">Preview</button>
+                <button class="tab-btn" data-tab="analysis">Analysis</button>
                 <button class="tab-btn" data-tab="categories">Categories</button>
             </div>
-            
-            <div class="tab-content active" id="selectionTab">
+
+            <div class="tab-content active" id="previewTab">
                 <details id="selectionSection" open>
                     <summary>Selection Preview</summary>
                     <div class="selection-info">
@@ -71,6 +72,9 @@
                     </div>
                 </details>
 
+            </div>
+
+            <div class="tab-content" id="analysisTab">
                 <details id="promptSection">
                     <summary>Analysis Prompt</summary>
                     <div class="action-panel">

--- a/styles.css
+++ b/styles.css
@@ -278,11 +278,11 @@ body {
     display: flex;
 }
 
-#selectionTab {
+#previewTab {
     gap: 0;
 }
 
-#selectionTab details:last-child {
+#previewTab details:last-child {
     margin-bottom: 0;
 }
 
@@ -302,7 +302,6 @@ body {
 .selection-info {
     padding: 20px;
     flex: 1;
-    overflow-y: auto;
     min-height: 0;
 }
 
@@ -478,6 +477,9 @@ details[open] .selection-info,
 details[open] .action-panel {
     flex: 1;
     min-height: 0;
+}
+
+details[open] .action-panel {
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- move prompt section to new `Analysis` tab
- rename `Selection` tab to `Preview`
- update CSS for new tab id
- mention new tabs in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871996c88848323820bf9d17500a6c8