### PR TITLE
Fix build fail from remote fonts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Text Embedding Explorer",
@@ -16,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- remove Google fonts from layout to avoid blocked requests

## Testing
- `npm run lint` *(fails: eslint errors in csv-parser.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68745862b74c8323aab7a5aa7eacc4df